### PR TITLE
Add rules for node v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Last Changes
 
+- [#2](https://github.com/LaxarJS/laxar/issues/2): add Node.js preset (`"extends": "laxarjs/node"`)
+
 
 ## v0.2.0
 

--- a/README.md
+++ b/README.md
@@ -18,4 +18,12 @@ In your project, create a file `.eslintrc.json` with the following contents:
 }
 ```
 
+Or, if you are building a Node.js package:
+
+```json
+{
+   "extends": "laxarjs/node"
+}
+```
+
 If applicable, define additional configuration rules, or override the *laxarjs* rules.

--- a/index.js
+++ b/index.js
@@ -5,8 +5,4 @@
  */
 /* eslint-env node */
 
-const fs = require( 'fs' );
-const path = require( 'path' );
-
-const configPath = path.join( __dirname, '.eslintrc.json' );
-module.exports = JSON.parse( fs.readFileSync( configPath, 'utf8' ) );
+module.exports = require( './.eslintrc.json' );

--- a/node.js
+++ b/node.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2016 aixigo AG
+ * Released under the MIT license.
+ * http://laxarjs.org/license
+ */
+/* eslint-env node */
+
+module.exports = {
+   extends: require.resolve( './index' ),
+   env: {
+      browser: false,
+      node: true
+   },
+   rules: {
+      // not supported by node v4:
+      'prefer-rest-params': 'off',
+      'prefer-spread': 'off',
+      'prefer-template': 'off'
+   }
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ESLint configuration settings for LaxarJS ES2015 repositories",
   "main": "index.js",
   "scripts": {
-    "test": "eslint index.js"
+    "test": "eslint index.js node.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@x1B, @alex3683: I added a config for Node.js.
It drops 3 rules (because the related features are not available in the current LTS version) and selects the `"node"` ESLint environment.

Merge?
